### PR TITLE
Add tests for scala3 enum derivation and fix writer derivation for scala3 enums

### DIFF
--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/AutoReaderDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/AutoReaderDerivationTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import tethys.JsonReader
 import tethys.commons.{Token, TokenNode}
-import tethys.commons.TokenNode.*
+import tethys.commons.TokenNode.{value => token, *}
 import tethys.derivation.auto.*
 import tethys.readers.ReaderError
 import tethys.readers.tokens.QueueIterator
@@ -65,5 +65,25 @@ class AutoReaderDerivationTest extends AnyFlatSpec with Matchers {
         )
       )
     )) shouldBe ComplexRecursionA(1, Some(ComplexRecursionB(2, ComplexRecursionA(3, None))))
+  }
+
+  it should "derive reader for simple enum" in {
+    read[SimpleEnum](
+      token(SimpleEnum.ONE.toString)
+    ) shouldBe SimpleEnum.ONE
+
+    read[SimpleEnum](
+      token(SimpleEnum.TWO.toString)
+    ) shouldBe SimpleEnum.TWO
+  }
+
+  it should "derive reader for parametrized enum" in {
+    read[ParametrizedEnum](
+      token(ParametrizedEnum.ONE.toString)
+    ) shouldBe ParametrizedEnum.ONE
+
+    read[ParametrizedEnum](
+      token(ParametrizedEnum.TWO.toString)
+    ) shouldBe ParametrizedEnum.TWO
   }
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/AutoWriterDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/AutoWriterDerivationTest.scala
@@ -3,7 +3,7 @@ package tethys.derivation
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import tethys.commons.TokenNode
-import tethys.commons.TokenNode.*
+import tethys.commons.TokenNode.{value => token,*}
 import tethys.derivation.ADTWithType.*
 import tethys.derivation.auto.*
 import tethys.derivation.semiauto.*
@@ -112,5 +112,15 @@ class AutoWriterDerivationTest extends AnyFlatSpec with Matchers {
     write(new SimpleClass(2)) shouldBe obj("b" -> 2)
     write(JustObject) shouldBe obj("type" -> "JustObject")
     write(SubChild(3)) shouldBe obj("c" -> 3)
+  }
+
+  it should "derive writer for simple enum" in {
+    SimpleEnum.ONE.asTokenList shouldBe token("ONE")
+    SimpleEnum.TWO.asTokenList shouldBe token("TWO")
+  }
+
+  it should "derive writer for parametrized enum" in {
+    ParametrizedEnum.ONE.asTokenList shouldBe token("ONE")
+    ParametrizedEnum.TWO.asTokenList shouldBe token("TWO")
   }
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoReaderDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoReaderDerivationTest.scala
@@ -3,7 +3,7 @@ package tethys.derivation
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 import tethys.JsonReader
-import tethys.commons.TokenNode.*
+import tethys.commons.TokenNode.{value => token, *}
 import tethys.commons.{Token, TokenNode}
 import tethys.derivation.builder.{FieldStyle, ReaderBuilder, ReaderDerivationConfig}
 import tethys.derivation.semiauto.*
@@ -322,5 +322,34 @@ class SemiautoReaderDerivationTest extends AnyFlatSpec with Matchers {
         "simple" -> 3
       ))
     }).getMessage shouldBe "Illegal json at '[ROOT]': unexpected field 'not_id_param', expected one of 'simple', 'id_param', 'some_param'"
+  }
+
+
+  it should "derive reader for simple enum" in {
+    implicit val oneReader: JsonReader[SimpleEnum.ONE.type] = jsonReader[SimpleEnum.ONE.type]
+    implicit val twoReader: JsonReader[SimpleEnum.TWO.type] = jsonReader[SimpleEnum.TWO.type]
+    implicit val simpleEnumReader: JsonReader[SimpleEnum] = jsonReader[SimpleEnum]
+
+    read[SimpleEnum](
+      token(SimpleEnum.ONE.toString)
+    )shouldBe SimpleEnum.ONE
+
+    read[SimpleEnum](
+      token(SimpleEnum.TWO.toString)
+    ) shouldBe SimpleEnum.TWO
+  }
+
+  it should "derive reader for parametrized enum" in {
+    implicit val oneReader: JsonReader[ParametrizedEnum.ONE.type] = jsonReader[ParametrizedEnum.ONE.type]
+    implicit val twoReader: JsonReader[ParametrizedEnum.TWO.type] = jsonReader[ParametrizedEnum.TWO.type]
+    implicit val parametrizedEnumReader: JsonReader[ParametrizedEnum] = jsonReader[ParametrizedEnum]
+
+    read[ParametrizedEnum](
+      token(ParametrizedEnum.ONE.toString)
+    ) shouldBe ParametrizedEnum.ONE
+
+    read[ParametrizedEnum](
+      token(ParametrizedEnum.TWO.toString)
+    ) shouldBe ParametrizedEnum.TWO
   }
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoWriterDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoWriterDerivationTest.scala
@@ -6,10 +6,11 @@ import tethys.commons.TokenNode
 import tethys.{JsonObjectWriter, JsonWriter}
 import tethys.derivation.builder.{FieldStyle, WriterBuilder, WriterDerivationConfig}
 import tethys.writers.tokens.SimpleTokenWriter.*
-import tethys.commons.TokenNode.*
+import tethys.commons.TokenNode.{value as token, *}
 import tethys.derivation.ADTWithType.{ADTWithTypeA, ADTWithTypeB}
 import tethys.derivation.semiauto.*
 import tethys.writers.instances.SimpleJsonObjectWriter
+import tethys.writers.tokens.SimpleTokenWriter
 
 class SemiautoWriterDerivationTest extends AnyFlatSpec with Matchers {
 
@@ -189,5 +190,45 @@ class SemiautoWriterDerivationTest extends AnyFlatSpec with Matchers {
     write(new SimpleClass(2)) shouldBe obj("b" -> 2, "__type" -> "SimpleClass")
     write(JustObject) shouldBe obj("__type" -> "JustObject")
     write(SubChild(3)) shouldBe obj("c" -> 3, "__type" -> "SubChild")
+  }
+
+  it should "derive writer for simple enum" in {
+    implicit val oneWriter: JsonObjectWriter[SimpleEnum.ONE.type] = jsonWriter[SimpleEnum.ONE.type]
+    implicit val twoWriter: JsonObjectWriter[SimpleEnum.TWO.type] = jsonWriter[SimpleEnum.TWO.type]
+    implicit val simpleEnumWriter: JsonWriter[SimpleEnum] = jsonWriter[SimpleEnum]
+    
+    SimpleEnum.ONE.asTokenList shouldBe token("ONE")
+    SimpleEnum.TWO.asTokenList shouldBe token("TWO")
+  }
+
+  it should "derive writer for parametrized enum" in {
+    implicit val oneWriter: JsonObjectWriter[ParametrizedEnum.ONE.type] = jsonWriter[ParametrizedEnum.ONE.type]
+    implicit val twoWriter: JsonObjectWriter[ParametrizedEnum.TWO.type] = jsonWriter[ParametrizedEnum.TWO.type]
+    implicit val parametrizedEnumWriter: JsonWriter[ParametrizedEnum] = jsonWriter[ParametrizedEnum]
+
+    ParametrizedEnum.ONE.asTokenList shouldBe token("ONE")
+    ParametrizedEnum.TWO.asTokenList shouldBe token("TWO")
+  }
+
+  it should "derive writer with discriminator for simple enum" in {
+    implicit val oneWriter: JsonObjectWriter[SimpleEnum.ONE.type] = jsonWriter[SimpleEnum.ONE.type]
+    implicit val twoWriter: JsonObjectWriter[SimpleEnum.TWO.type] = jsonWriter[SimpleEnum.TWO.type]
+    implicit val simpleEnumWriter: JsonWriter[SimpleEnum] = jsonWriter[SimpleEnum](
+      WriterDerivationConfig.empty.withDiscriminator("__type")
+    )
+
+    SimpleEnum.ONE.asTokenList shouldBe obj("__type" -> "ONE")
+    SimpleEnum.TWO.asTokenList shouldBe obj("__type" -> "TWO")
+  }
+
+  it should "derive writer with discriminator for parametrized enum" in {
+    implicit val oneWriter: JsonObjectWriter[ParametrizedEnum.ONE.type] = jsonWriter[ParametrizedEnum.ONE.type]
+    implicit val twoWriter: JsonObjectWriter[ParametrizedEnum.TWO.type] = jsonWriter[ParametrizedEnum.TWO.type]
+    implicit val simpleEnumWriter: JsonWriter[ParametrizedEnum] = jsonWriter[ParametrizedEnum](
+      WriterDerivationConfig.empty.withDiscriminator("__type")
+    )
+
+    ParametrizedEnum.ONE.asTokenList shouldBe obj ("__type" -> "ONE")
+    ParametrizedEnum.TWO.asTokenList shouldBe obj ("__type" -> "TWO")
   }
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/package.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/package.scala
@@ -24,4 +24,13 @@ package object derivation {
   case class SeqMaster4(a: Seq[Int])
 
   case class CamelCaseNames(someParam: Int, IDParam: Int, simple: Int)
+
+  enum SimpleEnum {
+    case ONE, TWO
+  }
+
+  enum ParametrizedEnum(val i: Int) {
+    case ONE extends ParametrizedEnum(1)
+    case TWO extends ParametrizedEnum(2)
+  }
 }


### PR DESCRIPTION
Add tests and fix bugs for https://github.com/tethys-json/tethys/pull/177
Should be merged after https://github.com/tethys-json/tethys/pull/177 .

Tests for simple and parametrized enums:
- semiauto derivation
- semiauto derivation with discriminator
- auto derivation

Bug:
Behaviour of derived writer before this pr (the same for parametrised enum):
`SimpleEnum.ONE` -> `{ "ONE" }`
`SimpleEnum.ONE` (with discriminator) -> `{ "ONE", "__type": "ONE" }`
Behaviour of derived writer after this pr (the same for parametrised enum):
`SimpleEnum.ONE` -> `"ONE"`
`SimpleEnum.ONE` (with discriminator) -> `{ "__type": "ONE" }`

Behaviour of reader derivation was not changed. 
Derived reader works like `"ONE"` -> `SimpleEnum.ONE` (the same for parametrised enum)

However if you will try to use JsonWriter.obj for enum values, but not for the enum itself, like:
```
implicit val oneWriter: JsonObjectWriter[SimpleEnum.ONE.type] = JsonWriter.obj[SimpleEnum.ONE.type].addField("type")(_ => "ONE")  
implicit val twoWriter: JsonObjectWriter[SimpleEnum.TWO.type] = JsonWriter.obj[SimpleEnum.TWO.type].addField("type")(_ => "TWO")  
implicit val simpleEnumWriter: JsonWriter[SimpleEnum] = jsonWriter[SimpleEnum]
```
  in version after this pr it will produce `"type": "ONE"` or `"type": "TWO"` without object start and object end 
  (in version before this pr it would produce `{"type": "ONE"}` or `{"type": "TWO"}`)

  But you can use JsonWriter.obj for just SimpleEnum, not for its values:
```
implicit val simpleEnumWriter: JsonWriter[SimpleEnum] = JsonWriter[SimpleEnum].addField("type")(_.toString)
```
  and get the correct behaviour of such writer: `SimpleEnum.ONE -> {"type": "ONE"}`