### PR TITLE
fix: remove explicit dependency on circe core that breaks bincompat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,7 +174,6 @@ lazy val benchmarks = project.in(modules / "benchmarks")
       "io.spray"          %% "spray-json"       % "1.3.6",
       "org.json4s"        %% "json4s-native"    % "3.6.10",
       "org.json4s"        %% "json4s-jackson"   % "3.6.10",
-      "io.circe"          %% "circe-core"       % "0.14.4",
       "io.circe"          %% "circe-generic"    % "0.13.0",
       "io.circe"          %% "circe-jawn"       % "0.13.0",
       "io.circe"          %% "circe-jackson210" % "0.13.0",


### PR DESCRIPTION
fix #220 