### PR TITLE
fix: warning "local var is never updated" for generated instance fixed

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # FIXME Use stable scala version
-        scala: [2.13.10, 3.3.1-RC1-bin-20230318-7226ba6-NIGHTLY]
+        scala: [2.13.12, 3.3.1-RC1-bin-20230318-7226ba6-NIGHTLY]
 
     steps:
       - uses: actions/checkout@v3

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala213 = "2.13.10"
+lazy val scala213 = "2.13.12"
 /* FIXME
 Return to use a stable version when 'scala.quoted.Quotes.reflectModuleSymbol.newClass'
 and 'scala.quoted.Quotes.reflectModule.ClassDef.apply' are no longer experimental methods
@@ -8,7 +8,7 @@ lazy val scala3 = "3.3.1-RC1-bin-20230318-7226ba6-NIGHTLY"
 ThisBuild / scalaVersion := scala3
 
 lazy val commonSettings = Seq(
-  version := "0.28.0",
+  version := "0.28.1",
   organization := "com.tethys-json",
   licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
   homepage := Some(url("https://github.com/tethys-json/tethys")),

--- a/modules/macro-derivation/src/main/scala-2.13+/tethys/derivation/impl/derivation/ReaderDerivation.scala
+++ b/modules/macro-derivation/src/main/scala-2.13+/tethys/derivation/impl/derivation/ReaderDerivation.scala
@@ -266,7 +266,7 @@ trait ReaderDerivation
     allTypes.foldLeft((List[(Type, TermName)](), List[Tree]())) {
       case ((types, trees), tpe) if !types.exists(_._1 =:= tpe) =>
         val term = TermName(c.freshName())
-        val default = q"private[this] var $term: $tpe = _"
+        val default = q"private[this] val $term: $tpe = null.asInstanceOf[$tpe]"
 
         (tpe -> term :: types, default :: trees)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.9.7


### PR DESCRIPTION
I tried to raise the Scala until 2.13.12, warnings like this started to appear

```
local var fresh$macro$16 in <$anon: tethys.JsonReader[Example]> is never updated: consider using immutable val
```

They arise because when generating `allocateDefaultValues` something like

```
private[this] var fresh$macro$16: Option[Boolean] = _;
private[this] var fresh$macro$15: Option[String] = _;
private[this] var fresh$macro$14: Int = _;
```

and then the values do not change. [Here](https://scastie.scala-lang.org/JOa0TWmgTyqn7OfhzOaudQ) minimal example and fix.