### PR TITLE
Use 3.3.0 lts compiler version instead of nightly

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # FIXME Use stable scala version
-        scala: [2.13.12, 3.3.1-RC1-bin-20230318-7226ba6-NIGHTLY]
+        scala: [2.13.12, 3.3.0]
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ gpg.sbt
 
 modules/**/target
 */jmh-result.json
+
+.metals
+.bloop

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,12 @@ lazy val scala213 = "2.13.12"
 Return to use a stable version when 'scala.quoted.Quotes.reflectModuleSymbol.newClass'
 and 'scala.quoted.Quotes.reflectModule.ClassDef.apply' are no longer experimental methods
  */
-lazy val scala3 = "3.3.1-RC1-bin-20230318-7226ba6-NIGHTLY"
+lazy val scala3 = "3.3.0"
 
 ThisBuild / scalaVersion := scala3
 
 lazy val commonSettings = Seq(
-  version := "0.28.1",
+  version := "0.28.2",
   organization := "com.tethys-json",
   licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
   homepage := Some(url("https://github.com/tethys-json/tethys")),

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/AutoDerivation.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/AutoDerivation.scala
@@ -5,6 +5,7 @@ import scala.quoted.*
 import tethys.{JsonObjectWriter, JsonReader}
 import tethys.commons.LowPriorityInstance
 import tethys.derivation.impl.derivation.AutoDerivationMacro
+import scala.annotation.experimental
 
 trait AutoDerivation {
   implicit inline def jsonWriterMaterializer[T]: LowPriorityInstance[JsonObjectWriter[T]] =
@@ -15,9 +16,11 @@ trait AutoDerivation {
 }
 
 private[this] object AutoDerivation {
+  @experimental
   def jsonWriterMaterializer[T: Type](using Quotes): Expr[LowPriorityInstance[JsonObjectWriter[T]]] =
     new AutoDerivationMacro(quotes).simpleJsonWriter[T]
 
+  @experimental
   def jsonReaderMaterializer[T: Type](using Quotes): Expr[LowPriorityInstance[JsonReader[T]]] =
     new AutoDerivationMacro(quotes).simpleJsonReader[T]
 }

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/SemiautoDerivation.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/SemiautoDerivation.scala
@@ -15,6 +15,7 @@ import tethys.derivation.impl.builder.{ReaderDescriptionMacro, WriterDescription
 import tethys.derivation.impl.derivation.SemiautoDerivationMacro
 import scala.quoted.*
 import scala.annotation.compileTimeOnly
+import scala.annotation.experimental
 
 trait SemiautoDerivation {
   inline def jsonWriter[T]: JsonObjectWriter[T] =
@@ -59,25 +60,31 @@ trait SemiautoDerivation {
 }
 
 private[this] object SemiautoDerivation {
+  @experimental
   def jsonWriter[T: Type](using Quotes): Expr[JsonObjectWriter[T]] =
     new SemiautoDerivationMacro(quotes).simpleJsonWriter[T]
 
+  @experimental
   def jsonWriterWithConfig[T: Type](config: Expr[WriterDerivationConfig])(using Quotes): Expr[JsonObjectWriter[T]] =
     new SemiautoDerivationMacro(quotes).jsonWriterWithConfig[T](config)
 
+  @experimental
   def jsonWriterWithDescription[T: Type](description: Expr[WriterDescription[T]])(using
       Quotes
   ): Expr[JsonObjectWriter[T]] =
     new SemiautoDerivationMacro(quotes).jsonWriterWithWriterDescription[T](description)
 
+  @experimental
   def jsonWriterWithBuilder[T <: Product: Type](builder: Expr[WriterBuilder[T]])(using
       Quotes
   ): Expr[JsonObjectWriter[T]] =
     new SemiautoDerivationMacro(quotes).jsonWriterWithBuilder[T](builder)
 
+  @experimental
   def describeWriter[T <: Product: Type](builder: Expr[WriterBuilder[T]])(using Quotes): Expr[WriterDescription[T]] =
     new WriterDescriptionMacro(quotes).simpleDescription[T](builder)
 
+  @experimental
   def jsonReader[T: Type](using Quotes): Expr[JsonReader[T]] =
     new SemiautoDerivationMacro(quotes).simpleJsonReader[T]
 

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/AutoDerivationMacro.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/AutoDerivationMacro.scala
@@ -5,6 +5,7 @@ import scala.quoted.*
 import tethys.{JsonObjectWriter, JsonReader, JsonWriter}
 import tethys.commons.LowPriorityInstance
 import tethys.writers.tokens.TokenWriter
+import scala.annotation.experimental
 
 class AutoDerivationMacro(val quotes: Quotes)
     extends WriterDerivation
@@ -13,6 +14,7 @@ class AutoDerivationMacro(val quotes: Quotes)
   import context.reflect.*
 
   // TODO: recursive A => B => A derivation check
+  @experimental
   def simpleJsonWriter[T: Type]: Expr[LowPriorityInstance[JsonObjectWriter[T]]] = {
     val tpe: TypeRepr = TypeRepr.of[T]
     val tpeSym: Symbol = tpe.typeSymbol
@@ -35,6 +37,7 @@ class AutoDerivationMacro(val quotes: Quotes)
     '{ LowPriorityInstance[JsonObjectWriter[T]]($jsonObjectWriterExpr) }
   }
 
+  @experimental
   def simpleJsonReader[T: Type]: Expr[LowPriorityInstance[JsonReader[T]]] = {
     val tpe: TypeRepr = TypeRepr.of[T]
     val tpeSym: Symbol = tpe.typeSymbol

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/SemiautoDerivationMacro.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/SemiautoDerivationMacro.scala
@@ -8,14 +8,17 @@ import tethys.readers.{FieldName, ReaderError}
 import tethys.readers.tokens.TokenIterator
 import tethys.{JsonObjectWriter, JsonReader, JsonWriter}
 import tethys.writers.tokens.TokenWriter
+import scala.annotation.experimental
 
 class SemiautoDerivationMacro(val quotes: Quotes) extends WriterDerivation with ReaderDerivation {
   implicit val context: Quotes = quotes
   import context.reflect.*
 
+  @experimental
   def simpleJsonWriter[T: Type]: Expr[JsonObjectWriter[T]] =
     jsonWriterWithMacroWriteDescription[T](MacroWriteDescription.empty[T])
 
+  @experimental
   def jsonWriterWithConfig[T: Type](config: Expr[WriterDerivationConfig]): Expr[JsonObjectWriter[T]] = {
     val tpe = TypeRepr.of[T]
 
@@ -28,6 +31,7 @@ class SemiautoDerivationMacro(val quotes: Quotes) extends WriterDerivation with 
     jsonWriterWithMacroWriteDescription[T](description)
   }
 
+  @experimental
   def jsonWriterWithMacroWriteDescription[T: Type](description: MacroWriteDescription): Expr[JsonObjectWriter[T]] = {
     val tpe = TypeRepr.of[T]
 
@@ -46,11 +50,13 @@ class SemiautoDerivationMacro(val quotes: Quotes) extends WriterDerivation with 
     else deriveTermWriter[T]
   }
 
+  @experimental
   def jsonWriterWithBuilder[T <: Product: Type](builder: Expr[WriterBuilder[T]]): Expr[JsonObjectWriter[T]] = {
     val description = convertWriterBuilder[T](builder)
     jsonWriterWithWriterDescription[T](description)
   }
 
+  @experimental
   def jsonWriterWithWriterDescription[T: Type](description: Expr[WriterDescription[T]]): Expr[JsonObjectWriter[T]] = {
     val tpe = TypeRepr.of[T]
     val tpeSym = tpe.typeSymbol
@@ -59,6 +65,7 @@ class SemiautoDerivationMacro(val quotes: Quotes) extends WriterDerivation with 
     else report.errorAndAbort(s"Can't derive json writer! ${tpe.show} isn't a Case Class")
   }
 
+  @experimental
   def simpleJsonReader[T: Type]: Expr[JsonReader[T]] = {
     val description = MacroReaderDescription(
       config = emptyReaderConfig,

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/WriterDerivation.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/impl/derivation/WriterDerivation.scala
@@ -10,11 +10,13 @@ import tethys.derivation.impl.builder.{WriterBuilderCommons, WriterBuilderUtils}
 import tethys.derivation.impl.FieldStyle
 import tethys.writers.tokens.{SimpleTokenWriter, TokenWriter}
 import tethys.{JsonObjectWriter, JsonWriter}
+import scala.annotation.experimental
 
 trait WriterDerivation extends WriterBuilderCommons {
   import context.reflect.*
 
   // ---------------------------------- CASE CLASS ----------------------------------
+  @experimental
   def deriveCaseClassWriter[T: Type](
     description: MacroWriteDescription
   ): Expr[JsonObjectWriter[T]] = {
@@ -58,6 +60,7 @@ trait WriterDerivation extends WriterBuilderCommons {
       }
     }
 
+  @experimental
   private def createDerivedWriterExpr[T: Type](
     clsSym: Symbol,
     clsParents: List[Tree],
@@ -124,6 +127,7 @@ trait WriterDerivation extends WriterBuilderCommons {
       case (rest, _) => rest
     }
 
+  @experimental
   private def createCaseClassWriterTerms(tpes: List[TypeRepr]): List[(TypeRepr, Term)] =
     tpes.map {
       _.asType match {
@@ -305,6 +309,7 @@ trait WriterDerivation extends WriterBuilderCommons {
   }
 
   // -------------------- SEALED (TRAIT | ABSTRACT CLASS) OR ENUM -------------------
+  @experimental
   def deriveSealedClassWriter[T: Type](
     cfg: Expr[WriterDerivationConfig]
   ): Expr[JsonObjectWriter[T]] = {
@@ -477,6 +482,7 @@ trait WriterDerivation extends WriterBuilderCommons {
   }
 
   // ------------------------------------ COMMON ------------------------------------
+  @experimental
   private def createClsSym(tpe: TypeRepr, declsFn: Symbol => List[Symbol]): Symbol =
     Symbol.newClass(
       parent = Symbol.spliceOwner,

--- a/modules/macro-derivation/src/main/scala-3/tethys/derivation/package.scala
+++ b/modules/macro-derivation/src/main/scala-3/tethys/derivation/package.scala
@@ -4,17 +4,21 @@ import scala.deriving.Mirror
 
 import tethys.{JsonObjectWriter, JsonReader, JsonWriter}
 import tethys.derivation.semiauto.{jsonReader, jsonWriter}
+import scala.annotation.experimental
 
 package object derivation {
   extension (underlying: JsonReader.type) {
+    @experimental
     inline def derived[T](using Mirror.Of[T]): JsonReader[T] = jsonReader[T]
   }
 
   extension (underlying: JsonWriter.type) {
+    @experimental
     inline def derived[T](using Mirror.Of[T]): JsonWriter[T] = jsonWriter[T]
   }
 
   extension (underlying: JsonObjectWriter.type) {
+    @experimental
     inline def derived[T](using Mirror.Of[T]): JsonObjectWriter[T] = jsonWriter[T]
   }
 }


### PR DESCRIPTION
Resolves #266 

Allows to use Scala 3 tethys artifact within projects with LTS Scala versions by exploiting a bug from Scala 3.3.0, which restricts proliferation of `@experimantal` scope at the level of inlines

A proper fix will require a substantial rewrite of macros and will follow soon, hopefully.