### PR TITLE
fix: support default values for case class fields

### DIFF
--- a/modules/macro-derivation/src/test/scala-2.13+/tethys/derivation/SemiautoReaderDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-2.13+/tethys/derivation/SemiautoReaderDerivationTest.scala
@@ -323,4 +323,23 @@ class SemiautoReaderDerivationTest extends AnyFlatSpec with Matchers {
       ))
     } should have message "Illegal json at '[ROOT]': unexpected field 'not_id_param', expected one of 'some_param', 'id_param', 'simple'"
   }
+  
+  it should "derive reader for class with default params" in {
+    implicit val reader: JsonReader[DefaultField[Int]] = jsonReader[DefaultField[Int]]
+
+    read[DefaultField[Int]](obj(
+      "value" -> 1,
+      "default" -> false
+    )) shouldBe DefaultField[Int](
+      value = 1,
+      default = false
+    )
+
+    read[DefaultField[Int]](obj(
+      "value" -> 1,
+    )) shouldBe DefaultField[Int](
+      value = 1,
+      default = true
+    )
+  }
 }

--- a/modules/macro-derivation/src/test/scala-2.13+/tethys/derivation/package.scala
+++ b/modules/macro-derivation/src/test/scala-2.13+/tethys/derivation/package.scala
@@ -24,4 +24,6 @@ package object derivation {
   case class SeqMaster4(a: Seq[Int])
 
   case class CamelCaseNames(someParam: Int, IDParam: Int, simple: Int)
+
+  case class DefaultField[T](value: T, default: Boolean = true)
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoReaderDerivationTest.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/SemiautoReaderDerivationTest.scala
@@ -352,4 +352,23 @@ class SemiautoReaderDerivationTest extends AnyFlatSpec with Matchers {
       token(ParametrizedEnum.TWO.toString)
     ) shouldBe ParametrizedEnum.TWO
   }
+
+  it should "derive reader for class with default params" in {
+    implicit val reader: JsonReader[DefaultField[Int]] = jsonReader[DefaultField[Int]]
+
+    read[DefaultField[Int]](obj(
+      "value" -> 1,
+      "default" -> false
+    )) shouldBe DefaultField[Int](
+      value = 1,
+      default = false
+    )
+
+    read[DefaultField[Int]](obj(
+      "value" -> 1
+    )) shouldBe DefaultField[Int](
+      value = 1,
+      default = true
+    )
+  }
 }

--- a/modules/macro-derivation/src/test/scala-3/tethys/derivation/package.scala
+++ b/modules/macro-derivation/src/test/scala-3/tethys/derivation/package.scala
@@ -33,4 +33,6 @@ package object derivation {
     case ONE extends ParametrizedEnum(1)
     case TWO extends ParametrizedEnum(2)
   }
+
+  case class DefaultField[T](value: T, default: Boolean = true)
 }


### PR DESCRIPTION
Prevously, default values wasn't supported at all - the json were required to have the field in json even if it was default.

Implements proper support for default values both for scala2 and scala3.

Fixes #300 