### PR TITLE
Adding generic configuration

### DIFF
--- a/modules/core/src/main/scala-3/tethys/JsonConfiguration.scala
+++ b/modules/core/src/main/scala-3/tethys/JsonConfiguration.scala
@@ -1,0 +1,12 @@
+package tethys
+
+trait JsonConfiguration[-A]:
+  def fieldStyle(fieldStyle: FieldStyle): JsonConfiguration[A]
+
+  def strict: JsonConfiguration[A]
+
+
+object JsonConfiguration:
+  @scala.annotation.compileTimeOnly("JsonConfiguration should be declared as inline given")
+  def apply[A]: JsonConfiguration[A] = throw IllegalAccessException()
+

--- a/modules/core/src/main/scala-3/tethys/JsonConfiguration.scala
+++ b/modules/core/src/main/scala-3/tethys/JsonConfiguration.scala
@@ -1,12 +1,12 @@
 package tethys
 
-trait JsonConfiguration[-A]:
-  def fieldStyle(fieldStyle: FieldStyle): JsonConfiguration[A]
+trait JsonConfiguration:
+  def fieldStyle(fieldStyle: FieldStyle): JsonConfiguration
 
-  def strict: JsonConfiguration[A]
+  def strict: JsonConfiguration
 
 
 object JsonConfiguration:
   @scala.annotation.compileTimeOnly("JsonConfiguration should be declared as inline given")
-  def apply[A]: JsonConfiguration[A] = throw IllegalAccessException()
+  def default: JsonConfiguration = throw IllegalAccessException()
 

--- a/modules/core/src/test/scala-3/tethys/derivation/DerivationSpec.scala
+++ b/modules/core/src/test/scala-3/tethys/derivation/DerivationSpec.scala
@@ -815,7 +815,7 @@ class DerivationSpec extends AnyFlatSpec with Matchers {
 
   it should "apply configuration for multiple case classes" in {
 
-    inline given JsonConfiguration[Any] = JsonConfiguration[Any]
+    inline given JsonConfiguration = JsonConfiguration.default
       .fieldStyle(FieldStyle.LowerSnakeCase)
 
     case class First(firstField: String) derives JsonWriter, JsonReader
@@ -834,7 +834,7 @@ class DerivationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "apply configuration when derive product recursively" in {
-    inline given JsonConfiguration[Any] = JsonConfiguration[Any]
+    inline given JsonConfiguration = JsonConfiguration.default
       .fieldStyle(FieldStyle.LowerSnakeCase)
 
     case class Inner(innerField: String)
@@ -848,7 +848,7 @@ class DerivationSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "apply configuration when derive sum recursively" in {
-    inline given JsonConfiguration[Any] = JsonConfiguration[Any]
+    inline given JsonConfiguration = JsonConfiguration.default
       .fieldStyle(FieldStyle.LowerSnakeCase)
     
     enum Choice(@selector val select: Int) derives JsonReader, JsonWriter:


### PR DESCRIPTION
Добавляем generic конфигурацию в tethys

1. Конфигурация должна быть compile-time
2. Должна быть поддержка FieldStyle и strict ридеров
3. Конфигурация должна подтягиваться для всех классов в зоне видимости
```scala
inline given JsonConfiguration = ???

case class Foo(foo: Int) derives JsonReader, JsonWriter // конфигурация должна подтянуться
case class Bar(bar: String) derives JsonReader, JsonWriter // конфигурация должна подтянуться
```

4. Конфигурация должна передаваться в рекурсивную деривацию (и для суммы и для продукта)
```scala
inline given JsonConfiguration = ???

case class Bar(bar: String) // конфигурация должна подтянуться
case class Foo(foo: Bar) derives JsonReader, JsonWriter // конфигурация должна подтянуться
```
