### PR TITLE
Add withRename extract setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ inline given ReaderBuilder[Foo] =
        case 2 => JsonReader[Int]
        case _ => JsonReader[Option[Boolean]]
     }
+
+    // rename field
+    .extract(_.f).withRename("newFieldName")
 ```
 
 

--- a/modules/core/src/main/scala-3/tethys/ReaderBuilder.scala
+++ b/modules/core/src/main/scala-3/tethys/ReaderBuilder.scala
@@ -5,7 +5,7 @@ import tethys.{FieldStyle, JsonReader}
 sealed trait ReaderBuilder[A]:
   def extract[Field](
       field: A => Field
-  ): ReaderBuilder.DependentFieldAs[A, Field]
+  ): ReaderBuilder.DependentFieldExtract[A, Field]
 
   def extractReader[Field](
       field: A => Field
@@ -31,8 +31,10 @@ object ReaderBuilder:
   sealed trait AsSyntax[A, B, C]:
     def apply(fun: B => C): ReaderBuilder[A]
 
-  sealed trait DependentFieldAs[A, B] extends DependentField0[A, B]:
+  sealed trait DependentFieldExtract[A, B] extends DependentField0[A, B]:
     def as[C]: ReaderBuilder.AsSyntax[A, C, B]
+
+    def withRename(newName: String): ReaderBuilder[A]
 
   sealed trait DependentField0[A, Field]:
     def apply(fun: () => Field): ReaderBuilder[A]

--- a/modules/core/src/test/scala-3/tethys/derivation/DerivationSpec.scala
+++ b/modules/core/src/test/scala-3/tethys/derivation/DerivationSpec.scala
@@ -822,4 +822,21 @@ class DerivationSpec extends AnyFlatSpec with Matchers {
     ) shouldBe SubChild(3)
   }
 
+  it should "derive reader for extract with renamed field" in {
+
+    inline given JsonReader[SimpleType] = JsonReader.derived[SimpleType] {
+      ReaderBuilder[SimpleType]
+        .extract(_.s)
+        .withRename("renamed")
+    }
+
+    read[SimpleType](
+      obj(
+        "renamed" -> "str",
+        "d" -> 1.0,
+        "i" -> 0
+      )
+    ) shouldBe SimpleType(0, "str", 1.0)
+
+  }
 }


### PR DESCRIPTION
Add `withRename` setting to `ReaderBuilder`, example:
```scala
final case class Foo(foo: String)

inline given JsonReader[Foo] = JsonReader.derived[Foo] {
  ReaderBuilder[Foo]
    .extract(_.foo)
    .withRename("bar")
}

read[Foo](
  obj(
    "bar" -> "test"
  )
) shouldBe Foo("test")
```