### PR TITLE
Update scala 3 quick start in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Read more about library usage bellow:
 val tethysVersion = "latest version in badge"
 libraryDependencies ++= Seq(
   "com.tethys-json" %% "tethys-core" % tethysVersion,
-  "com.tethys-json" %% "tethys-jackson" % tethysVersion
+  "com.tethys-json" %% "tethys-jackson213" % tethysVersion
 )
 ```
 


### PR DESCRIPTION
Hello,

`tethys-jackson` module is no longer published, so, there was a mistake in scala 3 quick start section.