### PR TITLE
Move const to JsonReader

### DIFF
--- a/modules/core/src/main/scala-3/tethys/derivation/JsonReaderDerivation.scala
+++ b/modules/core/src/main/scala-3/tethys/derivation/JsonReaderDerivation.scala
@@ -19,18 +19,6 @@ import scala.compiletime.{
 }
 
 private[tethys] trait JsonReaderDerivation:
-  def const[A](value: A): JsonReader[A] =
-    new JsonReader[A]:
-      override def read(it: TokenIterator)(implicit fieldName: FieldName): A =
-        if !it.currentToken().isObjectStart then
-          ReaderError.wrongJson(
-            "Expected object start but found: " + it.currentToken().toString
-          )
-        else {
-          it.skipExpression()
-          value
-        }
-
   inline def derived[A](inline config: ReaderBuilder[A])(using
       mirror: Mirror.ProductOf[A]
   ): JsonReader[A] =

--- a/modules/core/src/main/scala/tethys/JsonReader.scala
+++ b/modules/core/src/main/scala/tethys/JsonReader.scala
@@ -2,7 +2,7 @@ package tethys
 
 import tethys.readers.instances.AllJsonReaders
 import tethys.readers.tokens.TokenIterator
-import tethys.readers.{FieldName, JsonReaderBuilder}
+import tethys.readers.{FieldName, JsonReaderBuilder, ReaderError}
 
 import scala.language.higherKinds
 
@@ -25,6 +25,18 @@ trait JsonReader[@specialized(specializations) A] {
 
 object JsonReader extends AllJsonReaders with derivation.JsonReaderDerivation {
   def apply[A](implicit jsonReader: JsonReader[A]): JsonReader[A] = jsonReader
+
+  def const[A](value: A): JsonReader[A] = new JsonReader[A] {
+    override def read(it: TokenIterator)(implicit fieldName: FieldName): A =
+      if (!it.currentToken().isObjectStart)
+        ReaderError.wrongJson(
+          "Expected object start but found: " + it.currentToken().toString
+        )
+      else {
+        it.skipExpression()
+        value
+      }
+  }
 
   val builder: JsonReaderBuilder.type = JsonReaderBuilder
 }


### PR DESCRIPTION
I moved the `const` method into `JsonReader` companion, to make it available for scala 2. 

Fixes #63

PS. Maybe, we can move `emptyWriter` to `JsonWriter.empty` similarly? I don't know, but `EmptyWriters` seems strange for me