### PR TITLE
Remove noDefaultValue from implicit context

### DIFF
--- a/modules/core/src/main/scala-3/tethys/derivation/Derivation.scala
+++ b/modules/core/src/main/scala-3/tethys/derivation/Derivation.scala
@@ -21,6 +21,7 @@ import scala.compiletime.{constValueTuple, summonInline}
 import scala.quoted.*
 import scala.collection.mutable
 import scala.deriving.Mirror
+import tethys.readers.JsonReaderDefaultValue
 
 private[tethys] object Derivation:
 
@@ -536,6 +537,7 @@ private[derivation] class DerivationMacro(val quotes: Quotes)
             val term = Block(
               readers ++ discriminatorStats,
               '{
+                given defaultValue: JsonReaderDefaultValue[discriminator] = JsonReaderDefaultValue.noDefaultValue // TODO: summon a better default value from context
                 JsonReader.builder
                   .addField[discriminator](
                     name = ${ Expr(label) },

--- a/modules/core/src/main/scala/tethys/readers/JsonReaderBuilder.scala
+++ b/modules/core/src/main/scala/tethys/readers/JsonReaderBuilder.scala
@@ -27,6 +27,11 @@ object JsonReaderBuilder {
     )
   }
 
+  def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder1[B] = {
+    implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+    addField[B](name)
+  }
+
   trait SingleJsonValueReader[A1] {
     private[JsonReaderBuilder] def fields(
         arr: Array[SimpleJsonReader.FieldDefinition[_]]
@@ -69,6 +74,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder2[A1, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](fun: A1 => Res): JsonReader[Res] = {
@@ -133,6 +143,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder3[A1, A2, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](fun: (A1, A2) => Res): JsonReader[Res] = {
@@ -210,6 +225,11 @@ object JsonReaderBuilder {
       )
     }
 
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder4[A1, A2, A3, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
+    }
+
     def buildReader[Res](fun: (A1, A2, A3) => Res): JsonReader[Res] = {
       buildReader(strict = false, fun)
     }
@@ -284,6 +304,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder5[A1, A2, A3, A4, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](fun: (A1, A2, A3, A4) => Res): JsonReader[Res] = {
@@ -370,6 +395,11 @@ object JsonReaderBuilder {
       )
     }
 
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder6[A1, A2, A3, A4, A5, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
+    }
+
     def buildReader[Res](fun: (A1, A2, A3, A4, A5) => Res): JsonReader[Res] = {
       buildReader(strict = false, fun)
     }
@@ -454,6 +484,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -547,6 +582,11 @@ object JsonReaderBuilder {
       )
     }
 
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
+    }
+
     def buildReader[Res](
         fun: (A1, A2, A3, A4, A5, A6, A7) => Res
     ): JsonReader[Res] = {
@@ -637,6 +677,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -733,6 +778,11 @@ object JsonReaderBuilder {
       )
     }
 
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
+    }
+
     def buildReader[Res](
         fun: (A1, A2, A3, A4, A5, A6, A7, A8, A9) => Res
     ): JsonReader[Res] = {
@@ -826,6 +876,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -935,6 +990,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -1085,6 +1145,11 @@ object JsonReaderBuilder {
         A12,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -1250,6 +1315,11 @@ object JsonReaderBuilder {
         A13,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder14[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -1421,6 +1491,11 @@ object JsonReaderBuilder {
         A14,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder15[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -1643,6 +1718,11 @@ object JsonReaderBuilder {
         A15,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -1890,6 +1970,11 @@ object JsonReaderBuilder {
         A16,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder17[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -2179,6 +2264,11 @@ object JsonReaderBuilder {
         A17,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder18[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -2516,6 +2606,11 @@ object JsonReaderBuilder {
         A18,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder19[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -2867,6 +2962,11 @@ object JsonReaderBuilder {
         A19,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder20[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -3232,6 +3332,11 @@ object JsonReaderBuilder {
         A20,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder21[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -3611,6 +3716,11 @@ object JsonReaderBuilder {
         A21,
         B
       ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder22[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](
@@ -4101,6 +4211,11 @@ object JsonReaderBuilder {
         readerDefaultValue.defaultValue,
         jsonReader
       )
+    }
+
+    def addField[B: JsonReader](name: String, defaultValue: B): JsonReaderBuilder2[(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22), B] = {
+      implicit val jsonReaderDefaultValue = JsonReaderDefaultValueImpl(defaultValue)
+      addField[B](name)
     }
 
     def buildReader[Res](

--- a/modules/core/src/main/scala/tethys/readers/JsonReaderDefaultValue.scala
+++ b/modules/core/src/main/scala/tethys/readers/JsonReaderDefaultValue.scala
@@ -2,11 +2,15 @@ package tethys.readers
 
 import tethys.readers.JsonReaderDefaultValue.ReaderDefaultValue
 
+import scala.annotation.implicitNotFound
 import scala.annotation.StaticAnnotation
 
+//@implicitNotFound("Missing JsonReaderDefaultValue[${A}]")
 trait JsonReaderDefaultValue[A] {
   def defaultValue: Any
 }
+
+case class JsonReaderDefaultValueImpl[A](defaultValue: A) extends JsonReaderDefaultValue[A]
 
 object JsonReaderDefaultValue extends LowPriorityDefaultValue {
   def apply[A](implicit
@@ -34,6 +38,6 @@ trait LowPriorityDefaultValue {
 
   private val noDefaultValueInstance: NoDefaultValue[Nothing] =
     new NoDefaultValue[Nothing]
-  implicit def noDefaultValue[A]: NoDefaultValue[A] =
+  def noDefaultValue[A]: NoDefaultValue[A] =
     noDefaultValueInstance.asInstanceOf[NoDefaultValue[A]]
 }

--- a/modules/core/src/test/scala/tethys/readers/JsonReaderBuilderTest.scala
+++ b/modules/core/src/test/scala/tethys/readers/JsonReaderBuilderTest.scala
@@ -22,7 +22,7 @@ class JsonReaderBuilderTest extends AnyFlatSpec with Matchers {
   it should "build reader from fields" in {
     implicit val reader: JsonReader[B] = {
       JsonReader.builder
-        .addField[Int]("i")
+        .addField[Int]("i", 0)
         .buildReader(i => B(i))
     }
 
@@ -32,19 +32,19 @@ class JsonReaderBuilderTest extends AnyFlatSpec with Matchers {
   it should "build selecting reader from fields" in {
     implicit val readerB: JsonReader[B] = {
       JsonReader.builder
-        .addField[Int]("i")
+        .addField[Int]("i", 0)
         .buildReader(i => B(i))
     }
 
     implicit val readerC: JsonReader[C] = {
       JsonReader.builder
-        .addField[String]("s")
+        .addField[String]("s", "")
         .buildReader(s => C(s))
     }
 
     implicit val readerA: JsonReader[A] = {
       JsonReader.builder
-        .addField[String]("clazz")
+        .addField[String]("clazz", "")
         .selectReader[A] {
           case "B" => readerB
           case "C" => readerC
@@ -58,13 +58,13 @@ class JsonReaderBuilderTest extends AnyFlatSpec with Matchers {
   it should "build reader for fat object" in {
     implicit val reader: JsonReader[FatClass] = {
       JsonReader.builder
-        .addField[Int]("a")
-        .addField[String]("b")
-        .addField[Boolean]("c")
-        .addField[Seq[String]]("d")
-        .addField[Double]("e")
-        .addField[Char]("f")
-        .addField[Option[Int]]("opt")
+        .addField[Int]("a", 0)
+        .addField[String]("b", "")
+        .addField[Boolean]("c", false)
+        .addField[Seq[String]]("d", Seq())
+        .addField[Double]("e", 0.0)
+        .addField[Char]("f", Char.MinValue)
+        .addField[Option[Int]]("opt", None)
         .buildReader(FatClass.apply)
     }
 
@@ -133,30 +133,30 @@ class JsonReaderBuilderTest extends AnyFlatSpec with Matchers {
       )
     ] = {
       JsonReader.builder
-        .addField[Int]("f1")
-        .addField[Int]("f2")
-        .addField[Int]("f3")
-        .addField[Int]("f4")
-        .addField[Int]("f5")
-        .addField[Int]("f6")
-        .addField[Int]("f7")
-        .addField[Int]("f8")
-        .addField[Int]("f9")
-        .addField[Int]("f10")
-        .addField[Int]("f11")
-        .addField[Int]("f12")
-        .addField[Int]("f13")
-        .addField[Int]("f14")
-        .addField[Int]("f15")
-        .addField[Int]("f16")
-        .addField[Int]("f17")
-        .addField[Int]("f18")
-        .addField[Int]("f19")
-        .addField[Int]("f20")
-        .addField[Int]("f21")
-        .addField[Int]("f22")
-        .addField[Int]("f23")
-        .addField[Int]("f24")
+        .addField[Int]("f1", 0)
+        .addField[Int]("f2", 0)
+        .addField[Int]("f3", 0)
+        .addField[Int]("f4", 0)
+        .addField[Int]("f5", 0)
+        .addField[Int]("f6", 0)
+        .addField[Int]("f7", 0)
+        .addField[Int]("f8", 0)
+        .addField[Int]("f9", 0)
+        .addField[Int]("f10", 0)
+        .addField[Int]("f11", 0)
+        .addField[Int]("f12", 0)
+        .addField[Int]("f13", 0)
+        .addField[Int]("f14", 0)
+        .addField[Int]("f15", 0)
+        .addField[Int]("f16", 0)
+        .addField[Int]("f17", 0)
+        .addField[Int]("f18", 0)
+        .addField[Int]("f19", 0)
+        .addField[Int]("f20", 0)
+        .addField[Int]("f21", 0)
+        .addField[Int]("f22", 0)
+        .addField[Int]("f23", 0)
+        .addField[Int]("f24", 0)
         .buildReader((tuple, f23, f24) => (tuple, f23, f24))
     }
 
@@ -189,6 +189,17 @@ class JsonReaderBuilderTest extends AnyFlatSpec with Matchers {
       )
     )(reader) shouldBe ((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
       17, 18, 19, 20, 21, 22), 23, 24)
+  }
+
+  it should "fail on missing JsonReaderDefaultValue" in {
+
+    case class Response[T](payload: T, resultCode: String)
+
+    implicit def resp1[T: JsonReader: JsonReaderDefaultValue]: JsonReader[Response[T]] =
+      JsonReader.builder
+        .addField[T]("payload")
+        .addField[String]("resultCode", "")
+        .buildReader(Response(_, _))
   }
 }
 


### PR DESCRIPTION
Fix #361 BREAKING CHANGE

This MR removes `JsonReaderDefaultValue.noDefaultValue` from implicit context. After this change `JsonReaderDefaultValue` becomes a required type class argument for all generic types except `Option[T]`.