### PR TITLE
Add defaultValue directly to JsonReader

### DIFF
--- a/modules/ast/circe/src/main/scala/tethys/circe/ast/CirceSupport.scala
+++ b/modules/ast/circe/src/main/scala/tethys/circe/ast/CirceSupport.scala
@@ -56,6 +56,7 @@ trait CirceSupport {
 
           JsonObject.fromIterable(builder.result)
         }
+      override def defaultValue: JsonObject = JsonObject()
     }
 
   implicit lazy val circeJsonReader: JsonReader[Json] = new JsonReader[Json] {
@@ -87,6 +88,7 @@ trait CirceSupport {
       else if (token.isNullValue) { it.next(); Json.Null }
       else ReaderError.wrongJson(s"Unexpected token found: $token")(fieldName)
     }
+    override def defaultValue: Json = Json.Null
   }
 
   private[this] class TethysJsonFolder(writer: TokenWriter)

--- a/modules/ast/json4s/src/main/scala/tethys/json4s/ast/Json4sSupport.scala
+++ b/modules/ast/json4s/src/main/scala/tethys/json4s/ast/Json4sSupport.scala
@@ -113,6 +113,8 @@ trait Json4sSupport {
           JObject(builder.result())
         }
       }
+
+      override def defaultValue: JObject = JObject()
     }
   implicit lazy val json4sJArrayReader: JsonReader[JArray] =
     JsonReader[List[JValue]].map(JArray(_))
@@ -149,5 +151,6 @@ trait Json4sSupport {
         } else
           ReaderError.wrongJson(s"Unexpected token found: $token")(fieldName)
       }
+      override def defaultValue: JValue = org.json4s.JNull
     }
 }

--- a/modules/core/src/main/scala-3/tethys/OrdinalEnumJsonReader.scala
+++ b/modules/core/src/main/scala-3/tethys/OrdinalEnumJsonReader.scala
@@ -3,7 +3,8 @@ package tethys
 import tethys.readers.{FieldName, ReaderError}
 import tethys.readers.tokens.TokenIterator
 
-trait OrdinalEnumJsonReader[A] extends JsonReader[A]
+trait OrdinalEnumJsonReader[A] extends JsonReader[A]:
+  override def defaultValue: A = throw new IllegalArgumentException("OrdinalEnumJsonReader does not have default value")
 
 object OrdinalEnumJsonReader:
   def from[A](

--- a/modules/core/src/main/scala-3/tethys/StringEnumJsonReader.scala
+++ b/modules/core/src/main/scala-3/tethys/StringEnumJsonReader.scala
@@ -3,7 +3,9 @@ package tethys
 import tethys.readers.{FieldName, ReaderError}
 import tethys.readers.tokens.TokenIterator
 
-trait StringEnumJsonReader[A] extends JsonReader[A]
+trait StringEnumJsonReader[A] extends JsonReader[A]:
+  // override def defaultValue: A = null.asInstanceOf[A]
+  override def defaultValue: A = throw new IllegalArgumentException("StringEnumJsonReader does not have default value")
 
 object StringEnumJsonReader:
   def from[A](impl: TokenIterator => FieldName ?=> A): StringEnumJsonReader[A] =

--- a/modules/core/src/main/scala-3/tethys/derivation/Derivation.scala
+++ b/modules/core/src/main/scala-3/tethys/derivation/Derivation.scala
@@ -504,6 +504,8 @@ private[derivation] class DerivationMacro(val quotes: Quotes)
                     }.asTerm
                   ).asExprOf[T]
                 }
+            override def defaultValue: T = 
+              throw new IllegalArgumentException("There is no derived default value")
         }.asTerm
       )
       term.asExprOf[JsonReader[T]]

--- a/modules/core/src/main/scala-3/tethys/derivation/JsonReaderDerivation.scala
+++ b/modules/core/src/main/scala-3/tethys/derivation/JsonReaderDerivation.scala
@@ -30,6 +30,7 @@ private[tethys] trait JsonReaderDerivation:
           it.skipExpression()
           value
         }
+      override def defaultValue: A = value
 
   inline def derived[A](inline config: ReaderBuilder[A])(using
       mirror: Mirror.ProductOf[A]

--- a/modules/core/src/main/scala/tethys/JsonReader.scala
+++ b/modules/core/src/main/scala/tethys/JsonReader.scala
@@ -11,15 +11,20 @@ trait JsonReader[@specialized(specializations) A] {
 
   def read(it: TokenIterator)(implicit fieldName: FieldName): A
 
+  def defaultValue: A
+
   def map[B](fun: A => B): JsonReader[B] = new JsonReader[B] {
     override def read(it: TokenIterator)(implicit fieldName: FieldName): B =
       fun(self.read(it))
+
+    override def defaultValue: B = fun(self.defaultValue) 
   }
 
   def mapWithField[B](fun: FieldName => A => B): JsonReader[B] =
     new JsonReader[B] {
       override def read(it: TokenIterator)(implicit fieldName: FieldName): B =
         fun(fieldName)(self.read(it))
+      override def defaultValue: B = fun(FieldName("[defaultValue]"))(self.defaultValue) 
     }
 }
 

--- a/modules/core/src/main/scala/tethys/commons/RawJson.scala
+++ b/modules/core/src/main/scala/tethys/commons/RawJson.scala
@@ -27,5 +27,6 @@ object RawJson {
       tokenWriter.flush()
       RawJson(stringWriter.toString)
     }
+    override def defaultValue: RawJson = RawJson("null")
   }
 }

--- a/modules/core/src/main/scala/tethys/readers/JsonReaderBuilder.scala
+++ b/modules/core/src/main/scala/tethys/readers/JsonReaderBuilder.scala
@@ -2,27 +2,24 @@ package tethys.readers
 
 import tethys.JsonReader
 import tethys.readers.instances.{SelectingJsonReader, SimpleJsonReader}
+import scala.annotation.targetName
 
 object JsonReaderBuilder {
-  def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-      readerDefaultValue: JsonReaderDefaultValue[B]
-  ): JsonReaderBuilder1[B] = {
+  def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder1[B] = {
     new JsonReaderBuilder1[B](
       0,
       name,
-      readerDefaultValue.defaultValue,
       jsonReader
     )
   }
 
+  @targetName("addField1")
   def addField[B](name: String)(implicit
-      readerDefaultValue: JsonReaderDefaultValue[B],
       jsonReader: JsonReader[B]
   ): JsonReaderBuilder1[B] = {
     new JsonReaderBuilder1[B](
       0,
       name,
-      readerDefaultValue.defaultValue,
       jsonReader
     )
   }
@@ -38,35 +35,31 @@ object JsonReaderBuilder {
   final class JsonReaderBuilder1[A1] private[JsonReaderBuilder] (
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A1]
   ) extends SingleJsonValueReader[A1] {
     private[JsonReaderBuilder] def fields(
         arr: Array[SimpleJsonReader.FieldDefinition[_]]
     ): Unit = {
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A1](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A1](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): A1 = extracted(
       pos
     ).asInstanceOf[A1]
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder2[A1, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder2[A1, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder2[A1, B] = {
       new JsonReaderBuilder2[A1, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -101,7 +94,6 @@ object JsonReaderBuilder {
       prev: SingleJsonValueReader[A1],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A2]
   ) {
 
@@ -110,27 +102,24 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A2](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A2](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (A1, A2) =
       (prev.value(extracted), extracted(pos).asInstanceOf[A2])
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder3[A1, A2, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder3[A1, A2, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder3[A1, A2, B] = {
       new JsonReaderBuilder3[A1, A2, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -174,7 +163,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder2[A1, A2],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A3]
   ) {
 
@@ -183,7 +171,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A3](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A3](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (A1, A2, A3) =
@@ -191,21 +179,18 @@ object JsonReaderBuilder {
         case (a1, a2) => (a1, a2, extracted(pos).asInstanceOf[A3])
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder4[A1, A2, A3, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder4[A1, A2, A3, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder4[A1, A2, A3, B] = {
       new JsonReaderBuilder4[A1, A2, A3, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -249,7 +234,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder3[A1, A2, A3],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A4]
   ) {
 
@@ -258,7 +242,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A4](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A4](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -267,21 +251,18 @@ object JsonReaderBuilder {
       case (a1, a2, a3) => (a1, a2, a3, extracted(pos).asInstanceOf[A4])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder5[A1, A2, A3, A4, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder5[A1, A2, A3, A4, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder5[A1, A2, A3, A4, B] = {
       new JsonReaderBuilder5[A1, A2, A3, A4, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -333,7 +314,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder4[A1, A2, A3, A4],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A5]
   ) {
 
@@ -342,7 +322,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A5](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A5](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -351,21 +331,18 @@ object JsonReaderBuilder {
       case (a1, a2, a3, a4) => (a1, a2, a3, a4, extracted(pos).asInstanceOf[A5])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder6[A1, A2, A3, A4, A5, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder6[A1, A2, A3, A4, A5, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder6[A1, A2, A3, A4, A5, B] = {
       new JsonReaderBuilder6[A1, A2, A3, A4, A5, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -418,7 +395,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder5[A1, A2, A3, A4, A5],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A6]
   ) {
 
@@ -427,7 +403,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A6](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A6](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -437,21 +413,18 @@ object JsonReaderBuilder {
         (a1, a2, a3, a4, a5, extracted(pos).asInstanceOf[A6])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, B] = {
       new JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -509,7 +482,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder6[A1, A2, A3, A4, A5, A6],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A7]
   ) {
 
@@ -518,7 +490,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A7](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A7](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -528,21 +500,18 @@ object JsonReaderBuilder {
         (a1, a2, a3, a4, a5, a6, extracted(pos).asInstanceOf[A7])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, B] = {
       new JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -601,7 +570,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder7[A1, A2, A3, A4, A5, A6, A7],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A8]
   ) {
 
@@ -610,7 +578,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A8](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A8](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -620,21 +588,18 @@ object JsonReaderBuilder {
         (a1, a2, a3, a4, a5, a6, a7, extracted(pos).asInstanceOf[A8])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, B] = {
       new JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -695,7 +660,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder8[A1, A2, A3, A4, A5, A6, A7, A8],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A9]
   ) {
 
@@ -704,7 +668,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A9](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A9](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -714,21 +678,18 @@ object JsonReaderBuilder {
         (a1, a2, a3, a4, a5, a6, a7, a8, extracted(pos).asInstanceOf[A9])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, B] = {
       new JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -790,7 +751,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder9[A1, A2, A3, A4, A5, A6, A7, A8, A9],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A10]
   ) {
 
@@ -799,7 +759,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A10](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A10](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -809,21 +769,18 @@ object JsonReaderBuilder {
         (a1, a2, a3, a4, a5, a6, a7, a8, a9, extracted(pos).asInstanceOf[A10])
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B] = {
       new JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -886,7 +843,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder10[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A11]
   ) {
 
@@ -895,7 +851,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A11](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A11](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -918,21 +874,18 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B] = {
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B] = {
       new JsonReaderBuilder12[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
         this,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }
@@ -999,7 +952,6 @@ object JsonReaderBuilder {
       prev: JsonReaderBuilder11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A12]
   ) {
 
@@ -1008,7 +960,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A12](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A12](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -1032,9 +984,7 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder13[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder13[
       A1,
       A2,
       A3,
@@ -1049,11 +999,11 @@ object JsonReaderBuilder {
       A12,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder13[
       A1,
@@ -1084,7 +1034,7 @@ object JsonReaderBuilder {
         A11,
         A12,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -1160,7 +1110,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A13]
   ) {
 
@@ -1169,7 +1118,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A13](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A13](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -1194,9 +1143,7 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder14[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder14[
       A1,
       A2,
       A3,
@@ -1212,11 +1159,11 @@ object JsonReaderBuilder {
       A13,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder14[
       A1,
@@ -1249,7 +1196,7 @@ object JsonReaderBuilder {
         A12,
         A13,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -1327,7 +1274,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A14]
   ) {
 
@@ -1336,7 +1282,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A14](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A14](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -1362,9 +1308,7 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder15[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder15[
       A1,
       A2,
       A3,
@@ -1381,11 +1325,11 @@ object JsonReaderBuilder {
       A14,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder15[
       A1,
@@ -1420,7 +1364,7 @@ object JsonReaderBuilder {
         A13,
         A14,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -1545,7 +1489,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A15]
   ) {
 
@@ -1554,7 +1497,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A15](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A15](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -1581,9 +1524,7 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder16[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder16[
       A1,
       A2,
       A3,
@@ -1601,11 +1542,11 @@ object JsonReaderBuilder {
       A15,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder16[
       A1,
@@ -1642,7 +1583,7 @@ object JsonReaderBuilder {
         A14,
         A15,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -1772,7 +1713,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A16]
   ) {
 
@@ -1781,7 +1721,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A16](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A16](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(
@@ -1825,9 +1765,7 @@ object JsonReaderBuilder {
           )
       }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder17[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder17[
       A1,
       A2,
       A3,
@@ -1846,11 +1784,11 @@ object JsonReaderBuilder {
       A16,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder17[
       A1,
@@ -1889,7 +1827,7 @@ object JsonReaderBuilder {
         A15,
         A16,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -2041,7 +1979,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A17]
   ) {
 
@@ -2050,7 +1987,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A17](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A17](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -2111,9 +2048,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder18[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder18[
       A1,
       A2,
       A3,
@@ -2133,11 +2068,11 @@ object JsonReaderBuilder {
       A17,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder18[
       A1,
@@ -2178,7 +2113,7 @@ object JsonReaderBuilder {
         A16,
         A17,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -2372,7 +2307,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A18]
   ) {
 
@@ -2381,7 +2315,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A18](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A18](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -2445,9 +2379,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder19[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder19[
       A1,
       A2,
       A3,
@@ -2468,11 +2400,11 @@ object JsonReaderBuilder {
       A18,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder19[
       A1,
@@ -2515,7 +2447,7 @@ object JsonReaderBuilder {
         A17,
         A18,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -2717,7 +2649,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A19]
   ) {
 
@@ -2726,7 +2657,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A19](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A19](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -2793,9 +2724,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder20[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder20[
       A1,
       A2,
       A3,
@@ -2817,11 +2746,11 @@ object JsonReaderBuilder {
       A19,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder20[
       A1,
@@ -2866,7 +2795,7 @@ object JsonReaderBuilder {
         A18,
         A19,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -3076,7 +3005,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A20]
   ) {
 
@@ -3085,7 +3013,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A20](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A20](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -3155,9 +3083,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder21[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder21[
       A1,
       A2,
       A3,
@@ -3180,11 +3106,11 @@ object JsonReaderBuilder {
       A20,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder21[
       A1,
@@ -3231,7 +3157,7 @@ object JsonReaderBuilder {
         A19,
         A20,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -3449,7 +3375,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A21]
   ) {
 
@@ -3458,7 +3383,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A21](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A21](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -3531,9 +3456,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder22[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder22[
       A1,
       A2,
       A3,
@@ -3557,11 +3480,11 @@ object JsonReaderBuilder {
       A21,
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder22[
       A1,
@@ -3610,7 +3533,7 @@ object JsonReaderBuilder {
         A20,
         A21,
         B
-      ](this, pos + 1, name, readerDefaultValue.defaultValue, jsonReader)
+      ](this, pos + 1, name, jsonReader)
     }
 
     def buildReader[Res](
@@ -3836,7 +3759,6 @@ object JsonReaderBuilder {
       ],
       pos: Int,
       name: String,
-      defaultValue: Any,
       jsonReader: JsonReader[A22]
   ) {
     self =>
@@ -3846,7 +3768,7 @@ object JsonReaderBuilder {
     ): Unit = {
       prev.fields(arr)
       arr(pos) =
-        SimpleJsonReader.FieldDefinition[A22](name, defaultValue, jsonReader)
+        SimpleJsonReader.FieldDefinition[A22](name, jsonReader)
     }
 
     private[JsonReaderBuilder] def value(extracted: Array[Any]): (
@@ -3922,9 +3844,7 @@ object JsonReaderBuilder {
         )
     }
 
-    def addField[B](name: String, jsonReader: JsonReader[B])(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B]
-    ): JsonReaderBuilder2[
+    def addField[B](name: String, jsonReader: JsonReader[B]): JsonReaderBuilder2[
       (
           A1,
           A2,
@@ -3951,11 +3871,11 @@ object JsonReaderBuilder {
       ),
       B
     ] = {
-      addField[B](name)(readerDefaultValue, jsonReader)
+      addField[B](name)(jsonReader)
     }
 
+    @targetName("addField1") 
     def addField[B](name: String)(implicit
-        readerDefaultValue: JsonReaderDefaultValue[B],
         jsonReader: JsonReader[B]
     ): JsonReaderBuilder2[
       (
@@ -4098,7 +4018,6 @@ object JsonReaderBuilder {
         singleJsonValueReader,
         pos + 1,
         name,
-        readerDefaultValue.defaultValue,
         jsonReader
       )
     }

--- a/modules/core/src/main/scala/tethys/readers/instances/AllJsonReaders.scala
+++ b/modules/core/src/main/scala/tethys/readers/instances/AllJsonReaders.scala
@@ -20,6 +20,8 @@ trait AllJsonReaders extends OptionReaders {
           )
         }
       }
+
+      override def defaultValue: Boolean = false
     }
 
   implicit lazy val stringReader: JsonReader[String] = new JsonReader[String] {
@@ -36,14 +38,29 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: String = ""
   }
 
-  implicit lazy val charReader: JsonReader[Char] = stringReader.mapWithField {
-    implicit fieldName =>
-      {
-        case s if s.length == 1 => s.head
-        case s => ReaderError.wrongJson(s"Expected char value but found: $s")
+  implicit lazy val charReader: JsonReader[Char] = new JsonReader[Char] {
+    override def read(
+        it: TokenIterator
+    )(implicit fieldName: FieldName): Char = {
+      if (it.currentToken().isStringValue) {
+        val res = it.string()
+        it.next()
+        res match {
+          case s if s.length == 1 => s.head
+          case s => ReaderError.wrongJson(s"Expected char value but found: $s")
+        }
+      } else {
+        ReaderError.wrongJson(
+          s"Expected char value but found: ${it.currentToken()}"
+        )
       }
+    }
+
+    override def defaultValue: Char = 0
   }
 
   implicit lazy val numberReader: JsonReader[Number] = new JsonReader[Number] {
@@ -60,6 +77,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Number = 0
   }
 
   implicit lazy val byteReader: JsonReader[Byte] = new JsonReader[Byte] {
@@ -76,6 +95,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Byte = 0
   }
 
   implicit lazy val shortReader: JsonReader[Short] = new JsonReader[Short] {
@@ -92,6 +113,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Short = 0
   }
 
   implicit lazy val intReader: JsonReader[Int] = new JsonReader[Int] {
@@ -106,6 +129,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Int = 0
   }
 
   implicit lazy val longReader: JsonReader[Long] = new JsonReader[Long] {
@@ -122,6 +147,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Long = 0
   }
 
   implicit lazy val floatReader: JsonReader[Float] = new JsonReader[Float] {
@@ -138,6 +165,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Float = 0
   }
 
   implicit lazy val doubleReader: JsonReader[Double] = new JsonReader[Double] {
@@ -154,6 +183,8 @@ trait AllJsonReaders extends OptionReaders {
         )
       }
     }
+
+    override def defaultValue: Double = 0
   }
 
   implicit lazy val bigDecimalReader: JsonReader[BigDecimal] =

--- a/modules/core/src/main/scala/tethys/readers/instances/IterableReaders.scala
+++ b/modules/core/src/main/scala/tethys/readers/instances/IterableReaders.scala
@@ -122,6 +122,8 @@ private[tethys] trait LowPriorityIterableReaders
         )
     }
 
+    override def defaultValue: C[A] = cb.newBuilder.result()
+
     @tailrec
     private def recRead(
         i: Int,

--- a/modules/core/src/main/scala/tethys/readers/instances/MapReaders.scala
+++ b/modules/core/src/main/scala/tethys/readers/instances/MapReaders.scala
@@ -158,6 +158,8 @@ private[tethys] trait LowPriorityMapReaders extends IterableReaders {
         )
     }
 
+    override def defaultValue: M[K, A] = cb.newBuilder.result()
+
     @tailrec
     private def recRead(
         it: TokenIterator,

--- a/modules/core/src/main/scala/tethys/readers/instances/OptionReaders.scala
+++ b/modules/core/src/main/scala/tethys/readers/instances/OptionReaders.scala
@@ -97,6 +97,8 @@ private[tethys] trait LowPriorityOptionReaders extends MapReaders {
         readSomeValue(it)
       }
     }
+
+    override def defaultValue: Option[A] = None
   }
 
 }

--- a/modules/core/src/main/scala/tethys/readers/instances/SelectingJsonReader.scala
+++ b/modules/core/src/main/scala/tethys/readers/instances/SelectingJsonReader.scala
@@ -13,4 +13,6 @@ class SelectingJsonReader[A, B](simpleJsonReader: SimpleJsonReader[A])(
     val it2 = it1.copy()
     selector(simpleJsonReader.read(it1)).read(it2)
   }
+
+  override def defaultValue: B = selector(simpleJsonReader.defaultValue).defaultValue
 }

--- a/modules/integrations/cats/src/main/scala-3/tethys/catsInstances/NonEmptySetReader.scala
+++ b/modules/integrations/cats/src/main/scala-3/tethys/catsInstances/NonEmptySetReader.scala
@@ -22,5 +22,9 @@ trait NonEmptySetReader {
               s"Seq is empty and can't be converted to NonEmptySet"
             )
         }
+      override def defaultValue: NonEmptySet[T] = {
+        given FieldName = FieldName("[defaultValue]")
+        ReaderError.wrongJson("Seq is empty and can't be converted to NonEmptySet (in default value)")
+      }
     }
 }

--- a/modules/integrations/cats/src/main/scala/tethys/catsInstances/CatsReaders.scala
+++ b/modules/integrations/cats/src/main/scala/tethys/catsInstances/CatsReaders.scala
@@ -20,6 +20,10 @@ trait CatsReaders {
               s"List is empty and can't be converted to NonEmptyList"
             )
         }
+      override def defaultValue: NonEmptyList[T] = {
+        given FieldName = FieldName("[defaultValue]")
+        ReaderError.wrongJson("List is empty and can't be converted to NonEmptyList (in default value)")
+      }
     }
 
   implicit def readerForNev[T: JsonReader]: JsonReader[NonEmptyVector[T]] =
@@ -34,6 +38,10 @@ trait CatsReaders {
               s"Vector is empty and can't be converted to NonEmptyVector"
             )
         }
+      override def defaultValue: NonEmptyVector[T] = {
+        given FieldName = FieldName("[defaultValue]")
+        ReaderError.wrongJson("Vector is empty and can't be converted to NonEmptyVector (in default value)")
+      }
     }
 
   implicit def readerForChain[T: JsonReader]: JsonReader[Chain[T]] =
@@ -51,6 +59,10 @@ trait CatsReaders {
               s"Chain is empty and can't be converted to NonEmptyChain"
             )
         }
+      override def defaultValue: NonEmptyChain[T] = {
+        given FieldName = FieldName("[defaultValue]")
+        ReaderError.wrongJson("Chain is empty and can't be converted to NonEmptyChain (in default value)")
+      }
     }
 
 }

--- a/modules/integrations/cats/src/test/scala/tethys/CatsSupportTests.scala
+++ b/modules/integrations/cats/src/test/scala/tethys/CatsSupportTests.scala
@@ -1,6 +1,6 @@
 package tethys
 
-import cats.data._
+import _root_.cats.data._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import tethys.catsInstances._

--- a/modules/integrations/refined/src/main/scala/tethys/refined/TethysRefinedInstances.scala
+++ b/modules/integrations/refined/src/main/scala/tethys/refined/TethysRefinedInstances.scala
@@ -18,6 +18,11 @@ trait TethysRefinedInstances {
           fieldName: FieldName
       ): F[T, P] =
         fromEither(RefType[F].refine(JsonReader[T].read(it)))
+
+      override def defaultValue: F[T, P] = {
+        given FieldName = FieldName("[defaultValue]")
+        fromEither(RefType[F].refine(JsonReader[T].defaultValue)) 
+      }
     }
 
   implicit final def RefinedKeyReader[T, P, F[_, _]: RefType](implicit


### PR DESCRIPTION
Fix https://github.com/tethys-json/tethys/issues/361 BREAKING CHANGE

According to recommendation https://github.com/tethys-json/tethys/pull/371?notification_referrer_id=NT_kwDOAEo0ELMxNjU2NjI3NTkzMDo0ODYyOTky&notifications_query=is%3Aunread#issuecomment-2955866958 in #371 here is an attempt to add `defaultValue` directly to `JsonReader[T]`.

This MR removes the need of JsonReaderDefaultValue (though, not removing `JsonReaderDefaultValue` as recommended). However, this is still a breaking change, since it requires proper `defaultValue` implementation in custom `JsonReader`'s.
